### PR TITLE
0.7.0

### DIFF
--- a/build-release.yml
+++ b/build-release.yml
@@ -4,7 +4,7 @@ jobs:
     vmImage: $(vmImage)
 
   variables:
-    pakagesVersion: '0.6.11'
+    pakagesVersion: '0.7.0'
 
   workspace:
     clean: all

--- a/examples/demo/Demo.Domain/Services/UserTouchTrackingService.cs
+++ b/examples/demo/Demo.Domain/Services/UserTouchTrackingService.cs
@@ -5,7 +5,7 @@ using Demo.User;
 
 namespace Demo.Domain.Services
 {
-    public class UserTouchTrackingService : DomainService<UserTouchTrackingService>,
+    public class UserTouchTrackingService : AsynchronousDomainService<UserTouchTrackingService>,
         IDomainServiceIsStartedByAsync<UserId, UserNotesChangedEvent>
     {
         public Task HandleAsync(IDomainEvent<UserId, UserNotesChangedEvent> domainEvent)

--- a/examples/demo/Demo.Domain/User/Services/ProjectService.cs
+++ b/examples/demo/Demo.Domain/User/Services/ProjectService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Demo.User.Services
 {
-    public sealed class ProjectService : BaseDomainService<ProjectService>
+    public sealed class ProjectService : SynchronizedDomainService<ProjectService>
     {
         public async Task Create(UserAggregate user, ProjectId projectId, ProjectName projectName)
         {

--- a/examples/demo/Demo.Web/Startup.cs
+++ b/examples/demo/Demo.Web/Startup.cs
@@ -27,8 +27,12 @@ namespace Demo.Web
                 .AddSingleton("AAAA")
                 .AddEventFly("user-example")
                     .WithContext<UserContext>()
-                    .AddGraphQl()
-                    .AddSwagger();
+
+                .ConfigureGraphQl(options => options.BasePath = "/graphql")
+                    .WithConsole(options => options.BasePath = "/graphql-console")
+
+                .ConfigureWebApi(options => options.BasePath = "/api")
+                    .WithSwagger(options => options.BasePath = "/swagger");
 
             services
                 .AddMvcCore()

--- a/examples/demo/Demo.Web/Startup.cs
+++ b/examples/demo/Demo.Web/Startup.cs
@@ -31,8 +31,8 @@ namespace Demo.Web
                 .ConfigureGraphQl(options => options.BasePath = "/graphql")
                     .WithConsole(options => options.BasePath = "/graphql-console")
 
-                .ConfigureWebApi(options => options.BasePath = "/api")
-                    .WithSwagger(options => options.BasePath = "/swagger");
+                .ConfigureWebApi(options => options.BasePath = "/api-s")
+                    .WithSwagger(options => options.Url = "/swagger");
 
             services
                 .AddMvcCore()
@@ -43,9 +43,6 @@ namespace Demo.Web
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseEventFly();
-
-            app.UseEventFlyGraphQl();
-            app.UseEventFlySwagger();
 
             app.UseMvc(routes =>
             {

--- a/src/EventFly.Abstractions/EventFly.Abstractions.csproj
+++ b/src/EventFly.Abstractions/EventFly.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>EventFly</RootNamespace>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.Application/EventFly.Application.csproj
+++ b/src/EventFly.Application/EventFly.Application.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.Domain/Commands/CommandHandler.cs
+++ b/src/EventFly.Domain/Commands/CommandHandler.cs
@@ -53,7 +53,7 @@ namespace EventFly.Commands
 
         public abstract Task<IExecutionResult> Handle(TAggregate aggregate, TCommand command);
 
-        protected TDomainService Resolve<TDomainService>() where TDomainService : BaseDomainService<TDomainService>, new()
+        protected TDomainService Resolve<TDomainService>() where TDomainService : SynchronizedDomainService<TDomainService>, new()
         {
             var service = new TDomainService();
             service.Inject(_commandBus);

--- a/src/EventFly.Domain/DomainService/AsynchronousDomainService.cs
+++ b/src/EventFly.Domain/DomainService/AsynchronousDomainService.cs
@@ -15,10 +15,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace EventFly.DomainService
 {
-    public abstract class DomainService<TDomainService> : ReceiveActor, IDomainService
-        where TDomainService : DomainService<TDomainService>
+    public abstract class AsynchronousDomainService<TDomainService> : ReceiveActor, IDomainService
+        where TDomainService : AsynchronousDomainService<TDomainService>
     {
-        protected DomainService()
+        protected AsynchronousDomainService()
         {
             Logger = Context.GetLogger();
 

--- a/src/EventFly.Domain/DomainService/SynchronizedDomainService.cs
+++ b/src/EventFly.Domain/DomainService/SynchronizedDomainService.cs
@@ -2,8 +2,8 @@
 
 namespace EventFly.DomainService
 {
-    public abstract class BaseDomainService<TDomainService>
-        where TDomainService : BaseDomainService<TDomainService>, new()
+    public abstract class SynchronizedDomainService<TDomainService>
+        where TDomainService : SynchronizedDomainService<TDomainService>, new()
     {
         protected ICommandBus CommandBus { get; private set; }
 

--- a/src/EventFly.Domain/EventFly.Domain.csproj
+++ b/src/EventFly.Domain/EventFly.Domain.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.Extensions/EventFly.Extensions.csproj
+++ b/src/EventFly.Extensions/EventFly.Extensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.Infrastructure/EventFly.Infrastructure.csproj
+++ b/src/EventFly.Infrastructure/EventFly.Infrastructure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.Storages.EntityFramework/EventFly.Storages.EntityFramework.csproj
+++ b/src/EventFly.Storages.EntityFramework/EventFly.Storages.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.TestFixture/EventFly.TestFixture.csproj
+++ b/src/EventFly.TestFixture/EventFly.TestFixture.csproj
@@ -22,7 +22,7 @@
     <PackageTags>
       tdd;bdd;testing;akka;cqrs;es;eventsourcing;actors;actor-model
     </PackageTags>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <RepositoryUrl>https://github.com/Sporteco/EventFly</RepositoryUrl>

--- a/src/EventFly.Web/EventFly.Web.csproj
+++ b/src/EventFly.Web/EventFly.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.6.11</Version>
+    <Version>0.7.0</Version>
     <Authors>Sporteco</Authors>
     <Company>Sporteco</Company>
     <Copyright>Copyright (c) Sporteco 2018 - 2019</Copyright>

--- a/src/EventFly.Web/EventFlyMiddleware.cs
+++ b/src/EventFly.Web/EventFlyMiddleware.cs
@@ -5,18 +5,53 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using EventFly.Commands;
+using EventFly.Definitions;
+using EventFly.DependencyInjection;
 using EventFly.Queries;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace EventFly
 {
+    public sealed class EventFlyHttpOptions
+    {
+        public EventFlyHttpOptions(string basePath)
+        {
+            BasePath = basePath;
+        }
+
+        public string BasePath { get; set; }
+    }
+
+    public sealed class EventFlyHttpBuilder
+    {
+        public EventFlyHttpBuilder(EventFlyBuilder builder)
+        {
+            Builder = builder;
+        }
+
+        public EventFlyBuilder Builder { get; }
+        public IServiceCollection Services => Builder.Services;
+        public IApplicationDefinition ApplicationDefinition => Builder.ApplicationDefinition;
+    }
+
+    public static class BuilderExtensions
+    {
+        public static EventFlyHttpBuilder ConfigureWebApi(this EventFlyBuilder eventFlyBuilder, Action<EventFlyHttpOptions> optionsBuilder)
+        {
+            var options = new EventFlyHttpOptions("api");
+            optionsBuilder(options);
+            eventFlyBuilder.Services.AddSingleton(options);
+            return new EventFlyHttpBuilder(eventFlyBuilder);
+        }
+    }
 
     public class EventFlyMiddleware
     {
-        private static readonly Regex CommandPath = new Regex("/*api/(?<name>[a-z]+)/(?<version>\\d+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex QueryPath = new Regex("/*api/(?<name>[a-z]+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private readonly Regex CommandPath = new Regex("/*api/(?<name>[a-z]+)/(?<version>\\d+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private readonly Regex QueryPath = new Regex("/*api/(?<name>[a-z]+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private readonly RequestDelegate _next;
         private readonly ILogger _log;
         private readonly ISerializedCommandPublisher _serializedCommandPublisher;
@@ -25,6 +60,7 @@ namespace EventFly
         public EventFlyMiddleware(
           RequestDelegate next,
           ILogger<EventFlyMiddleware> log,
+          EventFlyHttpOptions options,
           ISerializedCommandPublisher serializedCommandPublisher,
           ISerializedQueryExecutor serializedQueryExecutor)
         {
@@ -32,6 +68,11 @@ namespace EventFly
             _log = log;
             _serializedCommandPublisher = serializedCommandPublisher;
             _serializedQueryExecutor = serializedQueryExecutor;
+
+            var basePath = "/*" + options.BasePath.Trim('/');
+
+            CommandPath = new Regex(basePath + "/(?<name>[a-z]+)/(?<version>\\d+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            QueryPath = new Regex(basePath + "/(?<name>[a-z0-9]+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
 
         public async Task Invoke(HttpContext context)

--- a/src/EventFly.Web/EventFlyMiddleware.cs
+++ b/src/EventFly.Web/EventFlyMiddleware.cs
@@ -15,9 +15,9 @@ using Newtonsoft.Json;
 
 namespace EventFly
 {
-    public sealed class EventFlyHttpOptions
+    public sealed class EventFlyWebApiOptions
     {
-        public EventFlyHttpOptions(string basePath)
+        public EventFlyWebApiOptions(string basePath)
         {
             BasePath = basePath;
         }
@@ -25,9 +25,9 @@ namespace EventFly
         public string BasePath { get; set; }
     }
 
-    public sealed class EventFlyHttpBuilder
+    public sealed class EventFlyWebApiBuilder
     {
-        public EventFlyHttpBuilder(EventFlyBuilder builder)
+        public EventFlyWebApiBuilder(EventFlyBuilder builder)
         {
             Builder = builder;
         }
@@ -39,19 +39,19 @@ namespace EventFly
 
     public static class BuilderExtensions
     {
-        public static EventFlyHttpBuilder ConfigureWebApi(this EventFlyBuilder eventFlyBuilder, Action<EventFlyHttpOptions> optionsBuilder)
+        public static EventFlyWebApiBuilder ConfigureWebApi(this EventFlyBuilder eventFlyBuilder, Action<EventFlyWebApiOptions> optionsBuilder)
         {
-            var options = new EventFlyHttpOptions("api");
+            var options = new EventFlyWebApiOptions("api");
             optionsBuilder(options);
             eventFlyBuilder.Services.AddSingleton(options);
-            return new EventFlyHttpBuilder(eventFlyBuilder);
+            return new EventFlyWebApiBuilder(eventFlyBuilder);
         }
     }
 
     public class EventFlyMiddleware
     {
-        private readonly Regex CommandPath = new Regex("/*api/(?<name>[a-z]+)/(?<version>\\d+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private readonly Regex QueryPath = new Regex("/*api/(?<name>[a-z]+)/{0,1}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private readonly Regex CommandPath;
+        private readonly Regex QueryPath;
         private readonly RequestDelegate _next;
         private readonly ILogger _log;
         private readonly ISerializedCommandPublisher _serializedCommandPublisher;
@@ -60,7 +60,7 @@ namespace EventFly
         public EventFlyMiddleware(
           RequestDelegate next,
           ILogger<EventFlyMiddleware> log,
-          EventFlyHttpOptions options,
+          EventFlyWebApiOptions options,
           ISerializedCommandPublisher serializedCommandPublisher,
           ISerializedQueryExecutor serializedQueryExecutor)
         {

--- a/src/EventFly.Web/GraphQL/BuilderExtensions.cs
+++ b/src/EventFly.Web/GraphQL/BuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace EventFly.GraphQL
             return provider.GetRequiredService(serviceType);
         }
 
-        public static EventFlyBuilder AddGraphQl(this EventFlyBuilder builder)
+        public static EventFlyHttpBuilder AddGraphQl(this EventFlyHttpBuilder builder)
         {
             var services = builder.Services;
             services.AddSingleton<IDocumentExecuter, DocumentExecuter>();
@@ -49,9 +49,8 @@ namespace EventFly.GraphQL
         }
         public static IApplicationBuilder UseEventFlyGraphQl(this IApplicationBuilder app)
         {
-	        
-            app.UseGraphQL<ISchema>();
-
+            var options = app.ApplicationServices.GetRequiredService<EventFlyHttpOptions>();
+            app.UseGraphQL<ISchema>("/" + options.BasePath.Trim('/'));
             app.UseGraphQLPlayground(new GraphQLPlaygroundOptions
             {
                 Path = "/graphql-console"

--- a/src/EventFly.Web/IApplicationBuilderExtensions.cs
+++ b/src/EventFly.Web/IApplicationBuilderExtensions.cs
@@ -1,4 +1,9 @@
 ﻿using EventFly.DependencyInjection;
+using EventFly.GraphQL;
+using EventFly.Swagger;
+using GraphQL.Server;
+using GraphQL.Server.Ui.Playground;
+using GraphQL.Types;
 using Microsoft.AspNetCore.Builder;
 
 namespace EventFly
@@ -11,6 +16,29 @@ namespace EventFly
                 .UseMiddleware<EventFlyMiddleware>()
                 .ApplicationServices
                 .UseEventFly();
+
+
+            if (builder.ApplicationServices.GetService(typeof(EventFlyGraphQlOptions)) is EventFlyGraphQlOptions optionsGraphQl)
+                builder.UseGraphQL<ISchema>("/" + optionsGraphQl.BasePath.Trim('/'));
+
+            if (builder.ApplicationServices.GetService(typeof(EventFlyGraphQlConsoleOptions)) is EventFlyGraphQlConsoleOptions optionsConsole)
+                builder.UseGraphQLPlayground(new GraphQLPlaygroundOptions
+                {
+                    Path = "/" + optionsConsole.BasePath.Trim('/')
+                });
+
+            if (builder.ApplicationServices.GetService(typeof(EventFlySwaggerOptions)) is EventFlySwaggerOptions optionsSwagger)
+            {
+                builder.UseSwagger();
+                builder.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/" + optionsSwagger.Url.Trim('/') + "/v1/swagger.json", optionsSwagger.Name);
+
+                    //c.OAuthClientId("swaggerui");
+                    //c.OAuthAppName("Swagger UI");
+                });
+            }
+
 
             return builder;
         }

--- a/src/EventFly.Web/Swagger/BuilderExtensions.cs
+++ b/src/EventFly.Web/Swagger/BuilderExtensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using Akka.Util;
 using EventFly.Commands;
+using EventFly.Definitions;
 using EventFly.DependencyInjection;
 using EventFly.Queries;
 using Microsoft.AspNetCore.Builder;
@@ -16,13 +17,28 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace EventFly.Swagger
 {
+    public sealed class EventFlySwaggerOptions
+    {
+        public EventFlySwaggerOptions(string url, string name)
+        {
+            Url = url;
+            Name = name;
+        }
+
+        public string Url { get; set; }
+        public string Name { get; set; }
+    }
+
     public static class BuilderExtensions
     {
-        public static EventFlyHttpBuilder AddSwagger(this EventFlyHttpBuilder builder)
+        public static EventFlyBuilder WithSwagger(this EventFlyWebApiBuilder builder, Action<EventFlySwaggerOptions> optionsBuilder)
         {
+            var options = new EventFlySwaggerOptions("swagger", Assembly.GetEntryAssembly().GetName().Name);
+            optionsBuilder(options);
+            builder.Services.AddSingleton(options);
+        
             var services = builder.Services;
             services.TryAdd(ServiceDescriptor.Transient<IApiDescriptionGroupCollectionProvider, CommandsApiDescriptionGroupCollectionProvider>());
-
 
             services.AddSwaggerGen(c =>
             {
@@ -37,9 +53,9 @@ namespace EventFly.Swagger
             });
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new Info {Title = "R3 API", Version = "v1"});
-                //c.OperationFilter<AuthorizeCheckOperationFilter>();
-                //c.OperationFilter<OperationFilter>();
+                c.SwaggerDoc("v1", new Info {Title = options.Name + " API", Version = "v1"});
+
+
                 c.OperationFilter<DescriptionFilter>();
                 c.SchemaFilter<ReadOnlyFilter>();
                 c.CustomSchemaIds(i => i.FullName);
@@ -58,23 +74,23 @@ namespace EventFly.Swagger
                 //	Scopes = currentScopes
                 //});
             });
-            return builder;
+            return builder.Builder;
         }
 
-        public static IApplicationBuilder UseEventFlySwagger(this IApplicationBuilder app)
-        {
+        //public static IApplicationBuilder UseEventFlySwagger(this IApplicationBuilder app)
+        //{
 
-            app.UseSwagger();
+        //    app.UseSwagger();
+        //    var options = app.ApplicationServices.GetRequiredService<EventFlySwaggerOptions>();
+        //    app.UseSwaggerUI(c =>
+        //    {
+        //        c.SwaggerEndpoint("/" + options.Url.Trim('/') + "/v1/swagger.json", options.Name);
 
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "R3");
-                
-                //c.OAuthClientId("swaggerui");
-                //c.OAuthAppName("Swagger UI");
-            });
-            return app;
-        }
+        //        //c.OAuthClientId("swaggerui");
+        //        //c.OAuthAppName("Swagger UI");
+        //    });
+        //    return app;
+        //}
 
     }
 

--- a/src/EventFly.Web/Swagger/BuilderExtensions.cs
+++ b/src/EventFly.Web/Swagger/BuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace EventFly.Swagger
 {
     public static class BuilderExtensions
     {
-        public static EventFlyBuilder AddSwagger(this EventFlyBuilder builder)
+        public static EventFlyHttpBuilder AddSwagger(this EventFlyHttpBuilder builder)
         {
             var services = builder.Services;
             services.TryAdd(ServiceDescriptor.Transient<IApiDescriptionGroupCollectionProvider, CommandsApiDescriptionGroupCollectionProvider>());

--- a/src/EventFly.Web/Swagger/CommandsApiDescriptionGroupCollectionProvider.cs
+++ b/src/EventFly.Web/Swagger/CommandsApiDescriptionGroupCollectionProvider.cs
@@ -24,11 +24,11 @@ namespace EventFly.Swagger
     {
         private readonly IApplicationDefinition _metadata;
         private readonly ApiDescriptionGroupCollectionProvider _internal;
-        private readonly EventFlyHttpOptions _options;
+        private readonly EventFlyWebApiOptions _options;
 
         public CommandsApiDescriptionGroupCollectionProvider(
           IApplicationDefinition applicationDefinition,
-          EventFlyHttpOptions options,
+          EventFlyWebApiOptions options,
           IActionDescriptorCollectionProvider actionDescriptorCollectionProvider,
           IEnumerable<IApiDescriptionProvider> apiDescriptionProviders)
         {

--- a/src/EventFly.Web/Swagger/CommandsApiDescriptionGroupCollectionProvider.cs
+++ b/src/EventFly.Web/Swagger/CommandsApiDescriptionGroupCollectionProvider.cs
@@ -24,12 +24,15 @@ namespace EventFly.Swagger
     {
         private readonly IApplicationDefinition _metadata;
         private readonly ApiDescriptionGroupCollectionProvider _internal;
+        private readonly EventFlyHttpOptions _options;
 
         public CommandsApiDescriptionGroupCollectionProvider(
           IApplicationDefinition applicationDefinition,
+          EventFlyHttpOptions options,
           IActionDescriptorCollectionProvider actionDescriptorCollectionProvider,
           IEnumerable<IApiDescriptionProvider> apiDescriptionProviders)
         {
+            _options = options;
             _metadata = applicationDefinition;
             _internal = new ApiDescriptionGroupCollectionProvider(actionDescriptorCollectionProvider, apiDescriptionProviders);
         }
@@ -55,7 +58,7 @@ namespace EventFly.Swagger
                 {
                     var type = query.Type;
                     var name = query.Name;
-                    var str = "api/" + query.Name;
+                    var str = _options.BasePath.Trim('/')+ "/" + query.Name;
                     var genericInterface = ReflectionExtensions.GetSubclassOfRawGenericInterface(typeof(IQuery<>), type);
                     if (!(genericInterface == null))
                     {
@@ -64,32 +67,35 @@ namespace EventFly.Swagger
                         var apiDescription2 = apiDescription1;
                         var actionDescriptor1 = new ControllerActionDescriptor();
                         actionDescriptor1.ActionConstraints = new List<IActionConstraintMetadata>
-            {
-                new HttpMethodActionConstraint(new[]
-                {
-                    "POST"
-                })
-            };
+                        {
+                            new HttpMethodActionConstraint(new[]
+                            {
+                                "POST"
+                            })
+                        };
+
                         actionDescriptor1.ActionName = name;
                         actionDescriptor1.ControllerName = "context";
                         actionDescriptor1.DisplayName = name;
                         actionDescriptor1.Parameters = new List<ParameterDescriptor>
-            {
-                new ParameterDescriptor
-                {
-                    Name = "query",
-                    ParameterType = type
-                }
-            };
+                        {
+                            new ParameterDescriptor
+                            {
+                                Name = "query",
+                                ParameterType = type
+                            }
+                        };
+
                         actionDescriptor1.MethodInfo = new CustomMethodInfo(name, type);
                         actionDescriptor1.ControllerTypeInfo = type.GetTypeInfo();
                         actionDescriptor1.RouteValues = new Dictionary<string, string>
-            {
-                {
-                    "controller",
-                    domain.Name
-                }
-            };
+                        {
+                            {
+                                "controller",
+                                domain.Name
+                            }
+                        };
+
                         var actionDescriptor2 = actionDescriptor1;
                         apiDescription2.ActionDescriptor = actionDescriptor2;
                         apiDescription1.HttpMethod = "POST";
@@ -100,12 +106,14 @@ namespace EventFly.Swagger
                             Type = genericArgument
                         });
                         var apiDescription3 = apiDescription1;
+
                         ((List<ApiParameterDescription>)apiDescription3.ParameterDescriptions).Add(new ApiParameterDescription
                         {
                             Name = "query",
                             Type = type,
                             Source = BindingSource.Body
                         });
+
                         apis.Add(apiDescription3);
                     }
                 }
@@ -123,7 +131,7 @@ namespace EventFly.Swagger
                 {
                     var type = allDefinition.Type;
                     var name = allDefinition.Name;
-                    var str = "api/" + allDefinition.Name + "/" + allDefinition.Version;
+                    var str = _options.BasePath.Trim('/') + "/" + allDefinition.Name + "/" + allDefinition.Version;
                     var subclassOfRawGeneric = ReflectionExtensions.GetSubclassOfRawGeneric(typeof(Command<>), type);
                     if (!(subclassOfRawGeneric == null))
                     {
@@ -167,7 +175,7 @@ namespace EventFly.Swagger
                             Type = typeof(IExecutionResult)
                         });
                         var apiDescription3 = apiDescription1;
-                        ((List<ApiParameterDescription>) apiDescription3.ParameterDescriptions).Add(new ApiParameterDescription
+                        ((List<ApiParameterDescription>)apiDescription3.ParameterDescriptions).Add(new ApiParameterDescription
                         {
                             Name = "request",
                             Type = type,

--- a/test/EventFly.Domain.Tests/DomainServiceTests.cs
+++ b/test/EventFly.Domain.Tests/DomainServiceTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace EventFly.Domain.Tests
 {
-    public class Service : DomainService<Service> { }
+    public class Service : AsynchronousDomainService<Service> { }
 
     public class DomainServiceTests : TestKit
     {


### PR DESCRIPTION
- Enable configuring WebApi and GraphQl endpoints via DI
- Rename to asynchronous and sync versions of domain services

```cs
            services
                .AddSingleton("AAAA")
                .AddEventFly("user-example")
                    .WithContext<UserContext>()

                .ConfigureGraphQl(options => options.BasePath = "/graphql")
                    .WithConsole(options => options.BasePath = "/graphql-console")

                .ConfigureWebApi(options => options.BasePath = "/api-s")
                    .WithSwagger(options => options.Url = "/swagger");
```